### PR TITLE
Feature/force selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ local-cloud/
 
 .turbo
 .vercel
+.idea

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -43,6 +43,7 @@ export type SelectProps = {
   style?: CSSProperties
   id?: string
   ghost?: boolean
+  disableReselect?: boolean
 }
 
 export const Select: FC<SelectProps> = ({
@@ -58,15 +59,20 @@ export const Select: FC<SelectProps> = ({
   name,
   id,
   ghost,
+  disableReselect,
 }) => {
   const openedRef = useRef<boolean>()
+  console.log("value", value)
   const [currentValue, open] = useSelect(options, value, {
     variant: 'over',
     filterable,
     placement: 'left',
     width: 'target',
     ...overlay,
-  })
+  },
+null,
+    disableReselect
+  )
   let labelValue: ReactNode = currentValue
 
   useEffect(() => {

--- a/src/hooks/useSelect.tsx
+++ b/src/hooks/useSelect.tsx
@@ -28,7 +28,8 @@ export function useSelect<T = any>(
     placeholder?: string
     style?: CSSProperties
   },
-  handler?: (selection: Data<T> | Event | any) => () => void | undefined
+  handler?: (selection: Data<T> | Event | any) => () => void | undefined,
+  disableReselect?: boolean,
 ): [
   SelectEvents | boolean | string | number | undefined,
   PropsEventHandler,
@@ -55,7 +56,14 @@ export function useSelect<T = any>(
         items: n,
         value: v,
         onChange: useCallback((value) => {
-          setValue(value)
+          if(disableReselect){
+            // do not set value if value is undefined
+            if(value){
+              setValue(value)
+            }
+          }else {
+            setValue(value)
+          }
         }, []),
       },
       position,

--- a/src/playground/stories/Selects.tsx
+++ b/src/playground/stories/Selects.tsx
@@ -38,6 +38,16 @@ export const Selects = () => {
               options: ['yes', 'no', 'for sure'],
             },
           },
+            {
+                props: {
+                    value: 'yes',
+                    disableReselect: true,
+                    onChange: () => console.log('Snurp'),
+                    placeholder: 'Forced selection...',
+                    label: 'Force',
+                    options: ['yes', 'no', 'for sure'],
+                },
+            },
           {
             code: ms,
           },


### PR DESCRIPTION
When reselecting the value, the component ended up with no selected value. By setting `disableReselect`  flag to `true`, the select component will always keep a selected value. 