### PR TITLE
Fix Tooltip 

### DIFF
--- a/src/hooks/useTooltip.tsx
+++ b/src/hooks/useTooltip.tsx
@@ -9,7 +9,7 @@ export const useTooltip = (
 ) => {
   const onMouseEnter = useOverlay(
     () => <>{text}</>,
-    null,
+    text,
     { variant: 'detached', position: position },
 
     undefined,


### PR DESCRIPTION
 Pass the text as the "props" property that triggers the underlining useCallback function.